### PR TITLE
Add support for the new CIMC release numbering and bump tet version to tet1

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 History
 =======
 
+0.9.13+tet1 (2024-2-16)
+-----------------------
+* Added support for new CIMC releae numbering (new commit https://github.com/TetrationAnalytics/imcsdk/commit/a03e67cea3c54ef276587f92214aa0de8a8afac5)
+
 0.9.13+tet (2023-7-19)
 ----------------------
 * Repackaged 0.9.13-tet to be PEP-440 (https://peps.python.org/pep-0440/) compliant by changing the version to 0.9.13+tet.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,7 +1,7 @@
 History
 =======
 
-0.9.13+tet1 (2024-2-16) 
+0.9.13+tet1 (2024-2-16)
 -----------------------
 * Added support for new CIMC releae numbering (new commit https://github.com/TetrationAnalytics/imcsdk/commit/a03e67cea3c54ef276587f92214aa0de8a8afac5)
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,7 +1,7 @@
 History
 =======
 
-0.9.13+tet1 (2024-2-16)
+0.9.13+tet1 (2024-2-16) 
 -----------------------
 * Added support for new CIMC releae numbering (new commit https://github.com/TetrationAnalytics/imcsdk/commit/a03e67cea3c54ef276587f92214aa0de8a8afac5)
 

--- a/imcsdk/__init__.py
+++ b/imcsdk/__init__.py
@@ -57,4 +57,4 @@ if os.path.exists('/tmp/imcsdk_debug'):
 
 __author__ = 'Cisco Systems'
 __email__ = 'ucs-python@cisco.com'
-__version__ = '0.9.13+tet'
+__version__ = '0.9.13+tet1'

--- a/imcsdk/imccoremeta.py
+++ b/imcsdk/imccoremeta.py
@@ -131,7 +131,7 @@ class ImcVersion(object):
               and self.__mr is not None
               and self.__patch.isdigit()
               and self.__mr.isdigit()
-              and len(self.__patch) > 6):
+              and len(self.__patch) < 6):
             log.debug("Interim version encountered: %s. MR version has been bumped up." % self.version)
             self.__mr = str(int(self.__mr) + 1)
             self.__patch = 'a'

--- a/imcsdk/imccoremeta.py
+++ b/imcsdk/imccoremeta.py
@@ -48,21 +48,11 @@ class ImcVersion(object):
         self.__patch = None
         self.__spin = None
 
-        # Matches major.minor(mr.patch), example 4.3(2.240002), new style of release numbering
+        # Matches major.minor(mr.patch), example 4.3(2.4) as well as 4.3(2.240002)
         match_pattern = re.compile("^(?P<major>[1-9][0-9]{0,2})\."
                                    "(?P<minor>(([0-9])|([1-9][0-9]{0,1})))\("
                                    "(?P<mr>(([0-9])|([1-9][0-9]{0,2})))\."
-                                   "(?P<patch>(([0-9]){6}))\)$")
-        match_obj = re.match(match_pattern, version)
-        if self._set_versions(match_obj):
-            return
-
-
-        # Matches major.minor(mr.patch), example 4.3(2.4)
-        match_pattern = re.compile("^(?P<major>[1-9][0-9]{0,2})\."
-                                   "(?P<minor>(([0-9])|([1-9][0-9]{0,1})))\("
-                                   "(?P<mr>(([0-9])|([1-9][0-9]{0,2})))\."
-                                   "(?P<patch>(([0-9])|([1-9][0-9]{0,4})))\)$")
+                                   "(?P<patch>(([0-9])|([1-9][0-9]{0,5})))\)$")
         match_obj = re.match(match_pattern, version)
         if self._set_versions(match_obj):
             return

--- a/imcsdk/imccoremeta.py
+++ b/imcsdk/imccoremeta.py
@@ -48,6 +48,17 @@ class ImcVersion(object):
         self.__patch = None
         self.__spin = None
 
+        # Matches major.minor(mr.patch), example 4.3(2.240002), new style of release numbering
+        match_pattern = re.compile("^(?P<major>[1-9][0-9]{0,2})\."
+                                   "(?P<minor>(([0-9])|([1-9][0-9]{0,1})))\("
+                                   "(?P<mr>(([0-9])|([1-9][0-9]{0,2})))\."
+                                   "(?P<patch>(([0-9]){6}))\)$")
+        match_obj = re.match(match_pattern, version)
+        if self._set_versions(match_obj):
+            return
+
+
+        # Matches major.minor(mr.patch), example 4.3(2.4)
         match_pattern = re.compile("^(?P<major>[1-9][0-9]{0,2})\."
                                    "(?P<minor>(([0-9])|([1-9][0-9]{0,1})))\("
                                    "(?P<mr>(([0-9])|([1-9][0-9]{0,2})))\."
@@ -56,6 +67,7 @@ class ImcVersion(object):
         if self._set_versions(match_obj):
             return
 
+        # Matches major.minor(mrpatch), example 4.3(2a)
         match_pattern = re.compile("^(?P<major>[1-9][0-9]{0,2})\."
                                    "(?P<minor>(([0-9])|([1-9][0-9]{0,1})))\("
                                    "(?P<mr>(([0-9])|([1-9][0-9]{0,2})))"
@@ -64,6 +76,7 @@ class ImcVersion(object):
         if self._set_versions(match_obj):
             return
 
+        # Matches major.minor(mr), example 4.3(2)
         match_pattern = re.compile("^(?P<major>[1-9][0-9]{0,2})\."
                                    "(?P<minor>(([0-9])|([1-9][0-9]{0,1})))\("
                                    "(?P<mr>(([0-9])|([1-9][0-9]{0,2})))\)$")
@@ -124,7 +137,11 @@ class ImcVersion(object):
         # In this scenario assume the version to be highest patch z
         if self.__spin is not None and self.__patch is None:
             self.__patch = 'z'
-        elif self.__patch is not None and self.__mr is not None and self.__patch.isdigit() and self.__mr.isdigit():
+        elif (self.__patch is not None
+              and self.__mr is not None
+              and self.__patch.isdigit()
+              and self.__mr.isdigit()
+              and len(self.__patch) > 6):
             log.debug("Interim version encountered: %s. MR version has been bumped up." % self.version)
             self.__mr = str(int(self.__mr) + 1)
             self.__patch = 'a'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.13+tet
+current_version = 0.9.13+tet1
 commit = False
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open('HISTORY.rst') as history_file:
 
 setup(
     name='imcsdk',
-    version='0.9.13+tet',
+    version='0.9.13+tet1',
     description="python SDK for Cisco UCS IMC",
     long_description=readme + '\n\n' + history,
     long_description_content_type='text/x-rst',


### PR DESCRIPTION
### Summary

New CIMC versions have a different format than the old release numbering.  The patch version is now a 6 digit numerical value instead of a letter.  This change allows for copmarisons using that patch version scheme.

This change is already in tet-ops main_dev.

### Testing Plan

Testing internally.

### Reviewers

@gkalele @atnsnm @kasivaku1 