### PR TITLE
[CSW-6010] Add support for python3.11

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 History
 =======
 
+0.9.13+tet2 (2024-7-9)
+----------------------
+* Added support for python 3.11
+
 0.9.13+tet1 (2024-2-16)
 -----------------------
 * Added support for new CIMC releae numbering (new commit https://github.com/TetrationAnalytics/imcsdk/commit/a03e67cea3c54ef276587f92214aa0de8a8afac5)

--- a/imcsdk/__init__.py
+++ b/imcsdk/__init__.py
@@ -57,4 +57,4 @@ if os.path.exists('/tmp/imcsdk_debug'):
 
 __author__ = 'Cisco Systems'
 __email__ = 'ucs-python@cisco.com'
-__version__ = '0.9.13+tet1'
+__version__ = '0.9.13+tet2'

--- a/imcsdk/imccoreutils.py
+++ b/imcsdk/imccoreutils.py
@@ -18,6 +18,7 @@ This module contains the ImcSdk Core utilities.
 import os
 import re
 import logging
+import sys
 
 from . import imcgenutils
 from . import mometa
@@ -76,7 +77,10 @@ def get_imc_obj(class_id, elem, mo_obj=None):
         return imcmethod.ExternalMethod(class_id)
     elif class_id in MO_CLASS_ID:
         mo_class = load_class(class_id)
-        mo_class_params = inspect.getargspec(mo_class.__init__)[0][2:]
+        if sys.version_info > (3, 0):
+            mo_class_params = inspect.getfullargspec(mo_class.__init__)[0][2:]
+        else:
+            mo_class_params = inspect.getargspec(mo_class.__init__)[0][2:]
         mo_class_param_dict = {}
         for param in mo_class_params:
             mo_class_param_dict[param] = None
@@ -189,7 +193,10 @@ def load_mo(elem):
 
     mo_class_id = elem.tag
     mo_class = load_class(mo_class_id)
-    mo_class_params = inspect.getargspec(mo_class.__init__)[0][2:]
+    if sys.version_info > (3, 0):
+        mo_class_params = inspect.getfullargspec(mo_class.__init__)[0][2:]
+    else:
+        mo_class_params = inspect.getargspec(mo_class.__init__)[0][2:]
     mo_class_param_dict = {}
     for param in mo_class_params:
         mo_class_param_dict[param] = elem.attrib[

--- a/imcsdk/imcmo.py
+++ b/imcsdk/imcmo.py
@@ -17,6 +17,7 @@ This module contains the ManagedObject and GenericManagedObject Class.
 
 import logging
 import os
+import sys
 
 from . import imcgenutils
 from . import imccoreutils
@@ -658,7 +659,10 @@ class GenericMo(ImcBase):
         import inspect
 
         mo_class = imccoreutils.load_class(class_id)
-        mo_class_params = inspect.getargspec(mo_class.__init__)[0][2:]
+        if sys.version_info > (3, 0):
+            mo_class_params = inspect.getfullargspec(mo_class.__init__)[0][2:]
+        else:
+            mo_class_params = inspect.getargspec(mo_class.__init__)[0][2:]
         mo_class_param_dict = {}
         for param in mo_class_params:
             prop = imccoreutils.get_prop_meta(mo_class, param)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.13+tet1
+current_version = 0.9.13+tet2
 commit = False
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open('HISTORY.rst') as history_file:
 
 setup(
     name='imcsdk',
-    version='0.9.13+tet1',
+    version='0.9.13+tet2',
     description="python SDK for Cisco UCS IMC",
     long_description=readme + '\n\n' + history,
     long_description_content_type='text/x-rst',


### PR DESCRIPTION
Add support for python 3.11 to our tetration specific branch for v0.9.13 and bump the tet iteration to 2.